### PR TITLE
Pin required dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-black
-connexion
-pre-commit
-protobuf
-pylint
+black==19.10b0
+connexion==2.6.0
+pre-commit==2.0.1
+protobuf==3.11.3
+pylint==2.4.4
 python_dateutil == 2.6.0
 setuptools >= 21.0.0


### PR DESCRIPTION
This pins the dependencies in `requirements.txt` to ensure that we can reproduce the exact environment and avoid any breaking changes that may come up in new versions of the packages.

There are a number of articles on why this is good practice, [here](https://www.promptworks.com/blog/pin-all-dependencies) is one of them.